### PR TITLE
Add a script with a deep link to install the app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "react-scripts": "^5.0.1"
       },
       "devDependencies": {
-        "@contentful/app-scripts": "^1.22.0",
+        "@contentful/app-scripts": "^1.23.0",
         "@contentful/node-apps-toolkit": "^3.4.2",
         "@testing-library/jest-dom": "5.17.0",
         "@testing-library/react": "14.2.2",
@@ -2098,9 +2098,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@contentful/app-scripts": {
-      "version": "1.22.0",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/app-scripts/1.22.0/52f04e3b29cd520752f480972934efd01ffbc4e9",
-      "integrity": "sha512-vtDHcCSf9fMtgr7LXIK+TPBtXteYJKPxuVWgg7fkaXMV9o9/4LhDjqg9UW9znYD5ILS3Kl/1fNkRmL1qLl62PA==",
+      "version": "1.23.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/app-scripts/1.23.0/3836730d73ed2c4ebd380b2b5a918430f28eb019",
+      "integrity": "sha512-kdhWNQGizWAQDypp1KuJvbZdXknmqR21y/7Eks8vkcAqkE0ToxEhfuaFNqnRYMVQANXrrzpvq3reJjtuJrBOyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2109,7 +2109,7 @@
         "bottleneck": "2.19.5",
         "chalk": "4.1.2",
         "commander": "12.1.0",
-        "contentful-management": "11.26.2",
+        "contentful-management": "11.27.0",
         "dotenv": "16.4.5",
         "ignore": "5.3.1",
         "inquirer": "8.2.6",
@@ -2123,24 +2123,6 @@
       "engines": {
         "node": ">=14",
         "npm": ">=6"
-      }
-    },
-    "node_modules/@contentful/app-scripts/node_modules/contentful-management": {
-      "version": "11.26.2",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.26.2.tgz",
-      "integrity": "sha512-Zen5JnDpkOFRGR+abjTowjuvWbqhqyJMnbkmBNQgAyj0pWgpGhLBs0XzZ7ZJUyRlqjkqN2I6oezaF7Bdk5hdGQ==",
-      "dev": true,
-      "dependencies": {
-        "@contentful/rich-text-types": "^16.3.0",
-        "@types/json-patch": "0.0.30",
-        "axios": "^1.6.2",
-        "contentful-sdk-core": "^8.1.0",
-        "fast-copy": "^3.0.0",
-        "lodash.isplainobject": "^4.0.6",
-        "type-fest": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@contentful/app-sdk": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
     "prettier": "prettier --write functions",
     "open-settings": "contentful-app-scripts open-settings",
+    "install-app": "contentful-app-scripts install",
     "create-resource-entities": "ts-node -T -r dotenv/config ./src/tools/create-resource-entities.ts"
   },
   "eslintConfig": {
@@ -42,7 +43,7 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^1.22.0",
+    "@contentful/app-scripts": "^1.23.0",
     "@contentful/node-apps-toolkit": "^3.4.2",
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "14.2.2",


### PR DESCRIPTION
Adding support for the new `install` script from `app-scripts` that takes the user directly to the environment / space picker page.