### PR TITLE
feat: handle empty query with trending items [DANTE-1619]

### DIFF
--- a/functions/helpers.ts
+++ b/functions/helpers.ts
@@ -68,6 +68,7 @@ export const getUrls = (
   return {
     prefixUrl: `https://www.themoviedb.org/${type}`,
     searchUrl: `https://api.themoviedb.org/3/search/${type}?query=${encodedQuery}&include_adult=false&language=en-US&page=${page}`,
+    trendingUrl: `https://api.themoviedb.org/3/trending/${type}/day?language=en-US`,
     lookupUrls: urns.map(
       (urn) => `https://api.themoviedb.org/3/${type}/${urn}?language=en-US`
     )

--- a/functions/searchHandler.ts
+++ b/functions/searchHandler.ts
@@ -33,10 +33,14 @@ export const searchHandler = async (
   event: ResourcesSearchRequest,
   context: FunctionEventContext<AppInstallationParameters>
 ): Promise<ResourcesSearchResponse> => {
-  const { prefixUrl, searchUrl } = getUrls(event.resourceType, {
+  const { prefixUrl, searchUrl, trendingUrl } = getUrls(event.resourceType, {
     query: event.query,
     page: event.pages?.nextCursor ?? '1'
   });
 
-  return fetchSearch(searchUrl, prefixUrl, context);
+  return fetchSearch(
+    !event.query ? trendingUrl : searchUrl,
+    prefixUrl,
+    context
+  );
 };


### PR DESCRIPTION
When the user opens the entry editor they will start from an empty query which results in an empty list, to make it more intuitive we want to return something, in this PR I am returning trending movies or people depending on the resource type

<img width="852" alt="Screenshot 2024-07-09 at 17 25 14" src="https://github.com/contentful-labs/extensible-resource-links-example/assets/4799048/3dc39250-d72f-45b0-bc4e-b896180234a6">

<img width="851" alt="Screenshot 2024-07-09 at 17 25 19" src="https://github.com/contentful-labs/extensible-resource-links-example/assets/4799048/bbf4176b-354d-4626-89c6-26da3ff24bff">
